### PR TITLE
Strip a prefix path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ SSL_CERT_PATH             | TLS: cert.pem file path.                          | 
 SSL_KEY_PATH              | TLS: key.pem file path.                           |          | -
 APP_PORT                  | The port number to be assigned for listening.     |          | 80
 ACCESS_LOG                | Send access logs to /dev/stdout.                  |          | false
+STRIP_PATH                | Strip path prefix.                                |          | -
 
 ### 2. Run the application
 

--- a/main.go
+++ b/main.go
@@ -168,6 +168,11 @@ func header(r *http.Request, key string) (string, bool) {
 func awss3(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
 
+	stripPath := os.Getenv("STRIP_PATH")
+	if len(stripPath) > 0 {
+		path = strings.Replace(path, stripPath, "", 1)
+	}
+
 	idx := strings.Index(path, "symlink.json")
 	if idx > -1 {
 		symlink, err := s3get(c.s3Bucket, c.s3KeyPrefix+path[:idx+12])


### PR DESCRIPTION
If you are using a prefix path in your URL the configuration
`STRIP_PATH` will remove this prefix.
For example:
export STRIP_PATH=/my-prefix
`/my-prefix/path/to/my/file` will transform to `path/to/my/file`