### PR TITLE
updated the way to create the aws session

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,7 +216,10 @@ func awss3(w http.ResponseWriter, r *http.Request) {
 }
 
 func s3get(backet, key string) (*s3.GetObjectOutput, error) {
-	sess := session.New(aws.NewConfig().WithRegion(c.awsRegion))
+    sess, err := session.NewSession(&aws.Config{Region: aws.String(c.awsRegion)})
+    if err != nil {
+        log.Printf("[service] unable to create aws session: %s", err)
+    }
 	req := &s3.GetObjectInput{
 		Bucket: aws.String(backet),
 		Key:    aws.String(key),


### PR DESCRIPTION
Changed  `session.New` to `session.NewSession`, because `session.New` is deprecated.
more info on: https://github.com/aws/aws-sdk-go/blob/master/aws/session/session.go

In addition, using `session.NewSession` allows to use AWS ECS task roles when running the container on ECS.