### PR TITLE
Enable HTTP range headers - RFC 7233

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func splitCsvLine(data string) []string {
 
 func awss3(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
-    rangeHeader := r.Header.Get("Range")
+	rangeHeader := r.Header.Get("Range")
 
 	if len(c.stripPath) > 0 {
 		path = strings.Replace(path, c.stripPath, "", 1)
@@ -318,8 +318,8 @@ func awss3(w http.ResponseWriter, r *http.Request) {
 	setIntHeader(w, "Content-Length", obj.ContentLength)
 	setStrHeader(w, "Content-Range", obj.ContentRange)
 	setStrHeader(w, "Content-Type", obj.ContentType)
+	setStrHeader(w, "ETag", obj.ETag)
 	setTimeHeader(w, "Last-Modified", obj.LastModified)
-
 
 	if obj.ContentRange != nil && len(*obj.ContentRange) > 0 {
 		w.WriteHeader(http.StatusPartialContent)
@@ -329,12 +329,11 @@ func awss3(w http.ResponseWriter, r *http.Request) {
 }
 
 func s3get(backet, key, rangeHeader string) (*s3.GetObjectOutput, error) {
-	var rangeHeaderAwsString *string = nil
+	var rangeHeaderAwsString *string
 
 	if len(rangeHeader) > 0 {
 		rangeHeaderAwsString = aws.String(rangeHeader)
 	}
-
 
 	req := &s3.GetObjectInput{
 		Bucket: aws.String(backet),

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func splitCsvLine(data string) []string {
 
 func awss3(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
-    rangeHeader := r.Header.Get("Range")
+        rangeHeader := r.Header.Get("Range")
 
 	if len(c.stripPath) > 0 {
 		path = strings.Replace(path, c.stripPath, "", 1)

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func splitCsvLine(data string) []string {
 
 func awss3(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
-        rangeHeader := r.Header.Get("Range")
+    rangeHeader := r.Header.Get("Range")
 
 	if len(c.stripPath) > 0 {
 		path = strings.Replace(path, c.stripPath, "", 1)
@@ -329,10 +329,17 @@ func awss3(w http.ResponseWriter, r *http.Request) {
 }
 
 func s3get(backet, key, rangeHeader string) (*s3.GetObjectOutput, error) {
+	var rangeHeaderAwsString *string = nil
+
+	if len(rangeHeader) > 0 {
+		rangeHeaderAwsString = aws.String(rangeHeader)
+	}
+
+
 	req := &s3.GetObjectInput{
 		Bucket: aws.String(backet),
 		Key:    aws.String(key),
-		Range:  aws.String(rangeHeader),
+		Range:  rangeHeaderAwsString,
 	}
 	return s3.New(awsSession()).GetObject(req)
 }


### PR DESCRIPTION
[RFC 7233](https://tools.ietf.org/html/rfc7233)

The Range HTTP request header indicates the part of a document that the server should return. Several parts can be requested with one Range header at once, and the server may send back these ranges in a multipart document. If the server sends back ranges, it uses the 206 Partial Content for the response.

**Syntax**
```
Range: <unit>=<range-start>-
Range: <unit>=<range-start>-<range-end>
Range: <unit>=<range-start>-<range-end>, <range-start>-<range-end>
Range: <unit>=<range-start>-<range-end>, <range-start>-<range-end>, <range-start>-<range-end>
```