### PR TITLE
Fix another prefix-related problem

### DIFF
--- a/main.go
+++ b/main.go
@@ -396,7 +396,7 @@ func s3listFiles(w http.ResponseWriter, r *http.Request, backet, key string) {
 	candidates := map[string]bool{}
 	updatedAt := map[string]time.Time{}
 	for _, obj := range result.Contents {
-		candidate := strings.Replace(aws.StringValue(obj.Key), key, "", -1)
+		candidate := strings.TrimPrefix(aws.StringValue(obj.Key), key)
 		if len(candidate) == 0 {
 			continue
 		}
@@ -404,7 +404,7 @@ func s3listFiles(w http.ResponseWriter, r *http.Request, backet, key string) {
 		updatedAt[candidate] = *obj.LastModified
 	}
 	for _, obj := range result.CommonPrefixes {
-		candidate := strings.Replace(aws.StringValue(obj.Prefix), key, "", -1)
+		candidate := strings.TrimPrefix(aws.StringValue(obj.Prefix), key)
 		if len(candidate) == 0 {
 			continue
 		}


### PR DESCRIPTION
This time, there was a problem in listing the things within a directory.  I had the following directory structure:

* `build`
   * `jenkins-go-package-build`

(in S3 as `build/jenkins-go-package-build/`)

Due to `strings.Replace` being called, the `build/` prefix was stripped from the front of string (correctly but also from the back of the string (incorrectly).  This caused any files/folders that had any part of the prefix in them to be incorrectly displayed and impossible to navigate to using the directory-listing mechanism.

The resulting directory structure was rendered as:

* `build`
   * `jenkins-go-package-`

This now correctly calls `strings.TrimPrefix`.