### PR TITLE
Guess bucket region using s3manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,11 +17,13 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"context"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 type config struct { // nolint
@@ -84,6 +86,13 @@ func main() {
 	}
 }
 
+func guessBucketRegion(bucket string) (string, error) {
+	sess := session.Must(session.NewSession(&aws.Config{}))
+	ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Second)
+	defer cancel()
+	return s3manager.GetBucketRegion(ctx, sess, bucket, "us-east-1")
+}
+
 func configFromEnvironmentVariables() *config {
 	if len(os.Getenv("AWS_ACCESS_KEY_ID")) == 0 {
 		log.Print("Not defined environment variable: AWS_ACCESS_KEY_ID")
@@ -96,9 +105,13 @@ func configFromEnvironmentVariables() *config {
 	}
 	region := os.Getenv("AWS_REGION")
 	if len(region) == 0 {
-		region = os.Getenv("AWS_DEFAULT_REGION")
-		if len(region) == 0 {
-			region = "us-east-1"
+		var err error
+		region, err = guessBucketRegion(os.Getenv("AWS_S3_BUCKET"))
+		if err != nil {
+			region = os.Getenv("AWS_DEFAULT_REGION")
+			if len(region) == 0 {
+				region = "us-east-1"
+			}
 		}
 	}
 	endpoint := os.Getenv("AWS_API_ENDPOINT")


### PR DESCRIPTION
If the AWS_REGION is not provided, let's guess bucket region
using s3manager.GetBucketRegion. `us-east-1` serves just as a
hint and allows us to successfully get region for any bucket
located in generic "aws" partition. It will NOT find buckets
located in "aws-cn" and "aws-us-gov" partitions. In these
cases, AWS_REGION env must be set.