### PR TITLE
Correct documentation to reflect correct defaults for CONTENT_ENCODING

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -40,7 +40,7 @@ CORS_MAX_AGE       | CORS における preflight リクエスト結果のキャ�
 APP_PORT                  | このサービスが待機する `ポート番号`                  |        | 80
 ACCESS_LOG                | 標準出力へアクセスログを送る                        |        | false
 STRIP_PATH                | 指定した Prefix を S3 のパスから削除                |         | -
-CONTENT_ENCODING          | リクエストが許可して入ればレスポンスを圧縮します       |        | false
+CONTENT_ENCODING          | リクエストが許可して入ればレスポンスを圧縮します       |        | true
 HEALTHCHECK_PATH          | 指定すると Basic 認証設定の有無などに依らず 200 OK を返します |   | -
 GET_ALL_PAGES_IN_DIR      | 指定ディレクトリの全てのオブジェクトを返す |          | false
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ APP_PORT                  | The port number to be assigned for listening.     | 
 APP_HOST                  | The host name used to the listener                |          | Listens on all available unicast and anycast IP addresses of the local system.
 ACCESS_LOG                | Send access logs to /dev/stdout.                  |          | false
 STRIP_PATH                | Strip path prefix.                                |          | -
-CONTENT_ENCODING          | Compress response data if the request allows.     |          | false
+CONTENT_ENCODING          | Compress response data if the request allows.     |          | true
 HEALTHCHECK_PATH          | If it's specified, the path always returns 200 OK |          | -
 GET_ALL_PAGES_IN_DIR      | If true will make several calls to get all pages of destination directory |          | false
 


### PR DESCRIPTION
###### Overview
* CONTENT_ENCODING environment variable currently defaults to true. The documentation states this defaults to false. This change corrects the documentation to reflect the actual default.

Solves for #21 