### PR TITLE
Fixed GET_ALL_PAGES_IN_DIR implementation

### DIFF
--- a/internal/service/amazon-s3.go
+++ b/internal/service/amazon-s3.go
@@ -37,7 +37,7 @@ func (c client) S3listObjects(bucket, prefix string) (*s3.ListObjectsOutput, err
 		func(page *s3.ListObjectsOutput, lastPage bool) bool {
 			result.CommonPrefixes = append(result.CommonPrefixes, page.CommonPrefixes...)
 			result.Contents = append(result.Contents, page.Contents...)
-			return len(page.CommonPrefixes) == 1000
+			return len(page.Contents) == 1000
 		})
 	return result, err
 }


### PR DESCRIPTION
Fixed GET_ALL_PAGES_IN_DIR option: need to check 'page.Contents' instead of 'page.CommonPrefixes', because S3 returns up to 1000 objects in the page in 'Contents' field of struct 'ListObjectsOutput'