### PR TITLE
Make docker container to be buildable from local state

### DIFF
--- a/docker/linux/2.0/Dockerfile
+++ b/docker/linux/2.0/Dockerfile
@@ -2,17 +2,22 @@
 # docker run -d -p 8080:80 -e AWS_REGION -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET pottava/s3-proxy
 
 FROM golang:1.13.7-alpine3.11 AS builder
+
+ARG APP_VERSION=v2.0.0
+
+WORKDIR /build
+
 RUN apk --no-cache add gcc musl-dev git
-RUN go get -u github.com/pottava/aws-s3-proxy
-WORKDIR /go/src/github.com/pottava/aws-s3-proxy
-ENV APP_VERSION=v2.0.0
-RUN git checkout "${APP_VERSION}" > /dev/null 2>&1
-RUN go mod download
-RUN go mod verify
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+
 RUN githash=$(git rev-parse --short HEAD 2>/dev/null) \
     && today=$(date +%Y-%m-%d --utc) \
     && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags '-s -w -X main.ver=${APP_VERSION} -X main.commit=${githash} -X main.date=${today}' \
+    -ldflags "-s -w -X main.ver=${APP_VERSION} -X main.commit=${githash} -X main.date=${today}" \
     -o /app
 
 FROM alpine:3.11 AS libs


### PR DESCRIPTION
Previous version required the changes to be published in a named repo, making local testing impossible.

This will also fix the `--version` endpoint to show the correct information instead of `${APP_VERSION}-${githash} (built at ${today})`