### PR TITLE
Pass the HTTP 416 code back from the proxy

### DIFF
--- a/internal/controllers/s3-error.go
+++ b/internal/controllers/s3-error.go
@@ -8,6 +8,12 @@ import (
 )
 
 func toHTTPError(err error) (int, string) {
+	if rerr, ok := err.(awserr.RequestFailure); ok {
+		switch rerr.StatusCode() {
+		case http.StatusRequestedRangeNotSatisfiable:
+			return rerr.StatusCode(), rerr.Message()
+		}
+	}
 	if aerr, ok := err.(awserr.Error); ok {
 		switch aerr.Code() {
 		case s3.ErrCodeNoSuchBucket, s3.ErrCodeNoSuchKey:


### PR DESCRIPTION
The HTTP 416 code is not an error but a legitimate response to an attempt to re-get a completely downloaded file.

The code to handle this HTTP code is structured in a way to allow more codes to be added if necessary.