### PR TITLE
Allow user to override Content-Type and Content-Disposition headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ MAX_IDLE_CONNECTIONS      | Allowed number of idle connections to the S3 storage
 IDLE_CONNECTION_TIMEOUT   | Allowed timeout to the S3 storage.                |          | 10
 DISABLE_COMPRESSION       | If true will pass encoded content through as-is.  |          | true
 INSECURE_TLS              | If true it will skip cert checks                  |          | false
+CONTENT_TYPE              | Override the default Content-Type response header |          | -
+CONTENT_DISPOSITION       | Override the default Content-Disposition response header |          | -
 
 ### 2. Run the application
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,6 @@ type config struct { // nolint
 	JwtSecretKey       string        // JWT_SECRET_KEY
 	ContentType        string        // Override default Content-Type
 	ContentDisposition string        // Override default Content-Disposition
-
 }
 
 // Setup configurations with environment variables

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,9 @@ type config struct { // nolint
 	DisableCompression bool          // DISABLE_COMPRESSION
 	InsecureTLS        bool          // Disables TLS validation on request endpoints.
 	JwtSecretKey       string        // JWT_SECRET_KEY
+	ContentType        string        // Override default Content-Type
+	ContentDisposition string        // Override default Content-Disposition
+
 }
 
 // Setup configurations with environment variables
@@ -128,6 +131,8 @@ func Setup() {
 		DisableCompression: disableCompression,
 		InsecureTLS:        insecureTLS,
 		JwtSecretKey:       os.Getenv("JWT_SECRET_KEY"),
+		ContentType:        os.Getenv("CONTENT_TYPE"),
+		ContentDisposition: os.Getenv("CONTENT_DISPOSITION"),
 	}
 	// Proxy
 	log.Printf("[config] Proxy to %v", Config.S3Bucket)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -38,6 +38,8 @@ func defaultConfig() *config {
 		IdleConnTimeout:    time.Duration(10) * time.Second,
 		DisableCompression: true,
 		InsecureTLS:        false,
+		ContentType:        "",
+		ContentDisposition: "",
 	}
 }
 
@@ -56,6 +58,8 @@ func TestChangeDefaults(t *testing.T) {
 	os.Setenv("IDLE_CONNECTION_TIMEOUT", "60")
 	os.Setenv("DISABLE_COMPRESSION", "FALSE")
 	os.Setenv("INSECURE_TLS", "t")
+	os.Setenv("CONTENT_TYPE", "application/octet-stream")
+	os.Setenv("CONTENT_DISPOSITION", "attachment")
 
 	Setup()
 
@@ -69,6 +73,8 @@ func TestChangeDefaults(t *testing.T) {
 	expected.IdleConnTimeout = time.Duration(60) * time.Second
 	expected.DisableCompression = false
 	expected.InsecureTLS = true
+	expected.ContentType = "application/octet-stream"
+	expected.ContentDisposition = "attachment"
 
 	assert.Equal(t, expected, Config)
 }

--- a/internal/controllers/s3.go
+++ b/internal/controllers/s3.go
@@ -107,7 +107,6 @@ func setHeadersFromAwsResponse(w http.ResponseWriter, obj *s3.GetObjectOutput, h
 	} else {
 		setStrHeader(w, "Expires", obj.Expires)
 	}
-	setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
 	setStrHeader(w, "Content-Encoding", obj.ContentEncoding)
 	setStrHeader(w, "Content-Language", obj.ContentLanguage)
 
@@ -116,7 +115,16 @@ func setHeadersFromAwsResponse(w http.ResponseWriter, obj *s3.GetObjectOutput, h
 		setIntHeader(w, "Content-Length", obj.ContentLength)
 	}
 	setStrHeader(w, "Content-Range", obj.ContentRange)
-	setStrHeader(w, "Content-Type", obj.ContentType)
+	if config.Config.ContentType == "" {
+		setStrHeader(w, "Content-Type", obj.ContentType)
+	} else {
+		setStrHeader(w, "Content-Type", &config.Config.ContentType)
+	}
+	if config.Config.ContentDisposition == "" {
+		setStrHeader(w, "Content-Disposition", obj.ContentDisposition)
+	} else {
+		setStrHeader(w, "Content-Disposition", &config.Config.ContentDisposition)
+	}
 	setStrHeader(w, "ETag", obj.ETag)
 	setTimeHeader(w, "Last-Modified", obj.LastModified)
 


### PR DESCRIPTION
This PR allows the user to override the Content-Type and Content-Disposition via environment variables.

In my use case, I can set `CONTENT_TYPE=application/octet-stream` and `CONTENT_DISPOSITION=attachment` to force the client to download the data.

This does not change the default behaviour of aws-s3-proxy.