### PR TITLE
update aws-s3-proxy Dockerfile version to 2.0.1

### DIFF
--- a/docker/linux/2.0/Dockerfile
+++ b/docker/linux/2.0/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.13.7-alpine3.11 AS builder
 RUN apk --no-cache add gcc musl-dev git
 RUN go get -u github.com/pottava/aws-s3-proxy
 WORKDIR /go/src/github.com/pottava/aws-s3-proxy
-ENV APP_VERSION=v2.0.0
+ENV APP_VERSION=v2.0.1
 RUN git checkout "${APP_VERSION}" > /dev/null 2>&1
 RUN go mod download
 RUN go mod verify


### PR DESCRIPTION
Just noticed that aws-s3-proxy have 2.0.1 fixing auth problem, but no Dockerfile updated with that version