### PR TITLE
Add verbose logging when enabled

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type config struct { // nolint
 	DisableCompression bool          // DISABLE_COMPRESSION
 	InsecureTLS        bool          // Disables TLS validation on request endpoints.
 	JwtSecretKey       string        // JWT_SECRET_KEY
+	VerboseLog         bool          // VERBOSE_LOG
 }
 
 // Setup configurations with environment variables
@@ -98,6 +99,10 @@ func Setup() {
 	if b, err := strconv.ParseBool(os.Getenv("INSECURE_TLS")); err == nil {
 		insecureTLS = b
 	}
+	verboseLog := false
+	if b, err := strconv.ParseBool(os.Getenv("VERBOSE_LOG")); err == nil {
+		verboseLog = b
+	}
 	Config = &config{
 		AwsRegion:          region,
 		AwsAPIEndpoint:     os.Getenv("AWS_API_ENDPOINT"),
@@ -128,6 +133,7 @@ func Setup() {
 		DisableCompression: disableCompression,
 		InsecureTLS:        insecureTLS,
 		JwtSecretKey:       os.Getenv("JWT_SECRET_KEY"),
+		VerboseLog:         verboseLog,
 	}
 	// Proxy
 	log.Printf("[config] Proxy to %v", Config.S3Bucket)


### PR DESCRIPTION
When using this tool I wanted to check the logs for the status of my requests and see exactly any reason for failure.  I can only see this in the html response, logging is useful so added an option for VERBOSE_LOG env variable with it will also print to logs.